### PR TITLE
Confirmation stage

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -35,7 +35,9 @@ gulp.task('coverage', function() {
 
 gulp.task('style', function() {
   return gulp.src('src/**/*.js')
-    .pipe(jscs());
+    .pipe(jscs({
+      fix: true
+    }));
 });
 
 gulp.task('default', ['lint', 'style', 'test']);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/radify/radiian#readme",
   "devDependencies": {
+    "deasync": "^0.1.0",
     "gulp": "^3.9.0",
     "gulp-istanbul": "^0.10.0",
     "gulp-jasmine": "^2.0.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,5 +13,54 @@
     .version(packageInfo.version)
     .parse(process.argv);
 
-  inquirer.prompt(questions, generator.generate);
+  var userHappy = false;
+  var submittedAnswers = null;
+
+  function clear() {
+    process.stdout.write("\u001b[2J\u001b[0;0H");
+  }
+
+  function go(questions) {
+    clear();
+    inquirer.prompt(questions, function(answers) {
+      inquirer.prompt([{
+        type: 'confirm',
+        name: 'confirm',
+        message: function() {
+          clear();
+          return 'Please confirm that your answers are correct.\n' +
+              JSON.stringify(answers, null, '  ') +
+            '\nAre these answers correct?';
+        },
+        default: true
+      }], function(confirmation) {
+        if (!confirmation.confirm) {
+          console.log(questions);
+          console.log(answers);
+
+          // load existing answers as defaults into questions so user is modifying,
+          // not starting from scratch
+          for (var i = 0; i < questions.length; i++) {
+            if (questions[i].default) {
+              questions[i].default = answers[questions[i].name];
+            }
+          }
+          go(questions);
+        } else {
+          submittedAnswers = answers;
+          userHappy = true;
+        }
+      });
+    });
+  }
+  go(questions);
+
+  require('deasync').loopWhile(function(){
+    return !userHappy;
+  });
+
+  console.log("Generating playbook for an app named " + submittedAnswers.appName + " in ./ansible...");
+  generator.generate(submittedAnswers);
+
+  console.log("... done! Check out ./ansible, it's full of creamy goodness");
 }());

--- a/src/lib/Generator.js
+++ b/src/lib/Generator.js
@@ -1,62 +1,67 @@
-var mustache = require('mustache');
-var fs = require('fs');
-var Q = require('q');
-var mkdirp = require('mkdirp');
+(function() {
+  'use strict';
 
-module.exports = {
-  generate: function(answers) {
+  var mustache = require('mustache');
+  var fs = require('fs');
+  var Q = require('q');
+  var mkdirp = require('mkdirp');
 
-    // create promise versions of read and write files and mkdirp
-    var read = Q.denodeify(fs.readFile);
-    var write = Q.denodeify(fs.writeFile);
-    var mkdir = Q.denodeify(mkdirp);
+  module.exports = {
+    generate: function(answers) {
 
-    /**
-     * render a template by injecting answers into it
-     * @param template string
-     * @returns string rendered template
-     */
-    function render(template) {
-      return mustache.render(template, answers);
+      // create promise versions of read and write files and mkdirp
+      var read = Q.denodeify(fs.readFile);
+      var write = Q.denodeify(fs.writeFile);
+      var mkdir = Q.denodeify(mkdirp);
+
+      /**
+       * render a template by injecting answers into it
+       * @param template string
+       * @returns string rendered template
+       */
+      function render(template) {
+        return mustache.render(template, answers);
+      }
+
+      /**
+       * Partial application - creates a function which allows reading and returns a promise
+       * @param template string
+       * @returns {Function} Promise
+       */
+      function getReader(template) {
+        return function() {
+          return read(__dirname + '/../templates/' + template, 'utf8');
+        };
+      }
+
+      /**
+       * Partial application - creates a function which allows file writing and returns a promise
+       * @param outputPath string e.g. 'out.txt'
+       * @returns {Function} Promise with parameter "compiledTemplate", which is ready to write to outputPath
+       */
+      function getWriter(outputPath) {
+        return function(compiledTemplate) {
+          return write(outputPath, compiledTemplate);
+        };
+      }
+
+      function handler(err) {
+        console.log(('Something went wrong'));
+        console.log(err);
+      }
+
+      // Kick off a promise chain
+      mkdir('ansible/inventory', '0755')
+        .then(getReader('ansible.cfg.mustache')).then(render).then(getWriter('ansible/ansible.cfg'))
+        .then(getReader('aws_keys.mustache')).then(render).then(getWriter('ansible/inventory/aws_keys'))
+        .then(getReader('destroy-old-nodes.yaml.mustache')).then(render).then(getWriter('ansible/destroy-old-nodes.yaml'))
+        .then(getReader('ec2.ini.mustache')).then(render).then(getWriter('ansible/inventory/ec2.ini'))
+        .then(getReader('ec2.py')).then(render).then(getWriter('ansible/inventory/ec2.py'))
+        .then(getReader('immutable.yaml.mustache')).then(render).then(getWriter('ansible/immutable.yaml'))
+        .then(getReader('provision.sh.mustache')).then(render).then(getWriter('ansible/provision.sh'))
+        .then(getReader('tag-old-nodes.yaml.mustache')).then(render).then(getWriter('ansible/tag-old-nodes.yaml'))
+        .catch(handler);
     }
+  };
 
-    /**
-     * Partial application - creates a function which allows reading and returns a promise
-     * @param template string
-     * @returns {Function} Promise
-     */
-    function getReader(template) {
-      return function() {
-        return read(__dirname + '/../templates/' + template, 'utf8');
-      };
-    }
-
-    /**
-     * Partial application - creates a function which allows file writing and returns a promise
-     * @param outputPath string e.g. 'out.txt'
-     * @returns {Function} Promise with parameter "compiledTemplate", which is ready to write to outputPath
-     */
-    function getWriter(outputPath) {
-      return function(compiledTemplate) {
-        return write(outputPath, compiledTemplate);
-      };
-    }
-
-    function handler(err) {
-      console.log(('Something went wrong'));
-      console.log(err);
-    }
-
-    // Kick off a promise chain
-    mkdir('ansible/inventory', '0755')
-      .then(getReader('ansible.cfg.mustache')).then(render).then(getWriter('ansible/ansible.cfg'))
-      .then(getReader('aws_keys.mustache')).then(render).then(getWriter('ansible/inventory/aws_keys'))
-      .then(getReader('destroy-old-nodes.yaml.mustache')).then(render).then(getWriter('ansible/destroy-old-nodes.yaml'))
-      .then(getReader('ec2.ini.mustache')).then(render).then(getWriter('ansible/inventory/ec2.ini'))
-      .then(getReader('ec2.py')).then(render).then(getWriter('ansible/inventory/ec2.py'))
-      .then(getReader('immutable.yaml.mustache')).then(render).then(getWriter('ansible/immutable.yaml'))
-      .then(getReader('provision.sh.mustache')).then(render).then(getWriter('ansible/provision.sh'))
-      .then(getReader('tag-old-nodes.yaml.mustache')).then(render).then(getWriter('ansible/tag-old-nodes.yaml'))
-      .catch(handler);
-  }
-};
+}());

--- a/src/lib/questions.js
+++ b/src/lib/questions.js
@@ -1,4 +1,6 @@
 (function() {
+  'use strict';
+
   var regexes = require('./regexes');
 
   function validateInput(value, regex, errorMessage) {
@@ -24,7 +26,7 @@
       type: 'input',
       name: 'appName',
       message: function() {
-        process.stdout.write('\033c');  // clears console
+        process.stdout.write("\u001b[2J\u001b[0;0H");
         return 'What is the name of your application?';
       },
       default: 'myApp'
@@ -317,17 +319,7 @@
           'base-64 string with nothing before or after';
       return validateInput(value, regex, errorMessage);
     }
-  }, {
-      type: 'confirm',
-      name: 'confirmation',
-      message: function(answers) {
-        process.stdout.write('\033c');  // clears console
-        return 'Please confirm that your answers are correct.\n' +
-          JSON.stringify(answers, null, '  ') +
-          '\nAre these answers correct?';
-      },
-      default: true
-    }];
+  }];
 
   module.exports = questions;
 }());


### PR DESCRIPTION
Firstly, I used deasync to make the program effectively wait until he user has signed off on the choices.

Secondly, rather than having confirm as a stage, have it as its own set of questions. This has two advantages:
1. It can be divorced from the sets of questions/answers
2. It makes it easy to copy the defaults across

I have also modified it so the defaults are updated from the user's answers, so the user is editing and not necessarily starting afresh. However, I suspect they get overwritten in some cases where the "myApp" substitution is taking place... Perhaps setting some kind of "custom default set" flag on the question and using that in the message function could ensure the user's custom selections are always used?
