### PR TITLE
[#100074656] Replay Loses Instance Size

### DIFF
--- a/lib/questions.js
+++ b/lib/questions.js
@@ -97,6 +97,7 @@
     message: function(answers) {
       return setInstanceSizeQuestion(answers);
     },
+    default: 't2.micro',
     choices: [
       't2.micro',
       't2.small',
@@ -112,6 +113,7 @@
     message: function(answers) {
       return setInstanceSizeQuestion(answers);
     },
+    default: 'm3.medium',
     choices: [
       'm3.medium',
       'm3.large',
@@ -127,6 +129,7 @@
     message: function(answers) {
       return setInstanceSizeQuestion(answers);
     },
+    default: 'm4.large',
     choices: [
       'm4.large',
       'm4.xlarge',
@@ -143,6 +146,7 @@
     message: function(answers) {
       return setInstanceSizeQuestion(answers);
     },
+    default: 'c3.large',
     choices: [
       'c3.large',
       'c3.xlarge',
@@ -159,6 +163,7 @@
     message: function(answers) {
       return setInstanceSizeQuestion(answers);
     },
+    default: 'c4.large',
     choices: [
       'c4.large',
       'c4.xlarge',
@@ -175,6 +180,7 @@
     message: function(answers) {
       return setInstanceSizeQuestion(answers);
     },
+    default: 'r3.large',
     choices: [
       'r3.large',
       'r3.xlarge',
@@ -191,6 +197,7 @@
     message: function(answers) {
       return setInstanceSizeQuestion(answers);
     },
+    default: 'g2.2xlarge',
     choices: [
       'g2.2xlarge',
       'g2.8xlarge'
@@ -204,6 +211,7 @@
     message: function(answers) {
       return setInstanceSizeQuestion(answers);
     },
+    default: 'i2.xlarge',
     choices: [
       'i2.xlarge',
       'i2.2xlarge',
@@ -219,6 +227,7 @@
     message: function(answers) {
       return setInstanceSizeQuestion(answers);
     },
+    default: 'd2.xlarge',
     choices: [
       'd2.xlarge',
       'd2.2xlarge',

--- a/lib/radiian-init.js
+++ b/lib/radiian-init.js
@@ -27,9 +27,6 @@
         default: true
       }], function(confirmation) {
         if (!confirmation.confirm) {
-          console.log(questions);
-          console.log(answers);
-
           // load existing answers as defaults into questions so user is modifying,
           // not starting from scratch
           for (var i = 0; i < questions.length; i++) {


### PR DESCRIPTION
## [#100074656] Replay Loses Instance Size
### Description
- During the "replay" of radiian, the user is conveniently presented new default values based on previous entries.
- There was a bug where _instance_size_ did not retain its new default value. 
- All nine _instance_size_ answer objects were missing default value fields. This caused the bug. 
- This PR adds default values to those nine answer objects, thus fixing the bug. 
### Dependencies
- Relies upon PR #15 
### Test Script
1. Run `gulp`. **Assert that** it passes.
2. Run `radiian init`. 
   1. Choose `T2` and a value other than the default, `t2.micro`. 
   2. On the last question, answer "no" to the confirmation
   3. Run through the answers. 
      1. **Assert that** the family_choice defaults to your previous choice (in this case, `T2`).
      2. **Assert that** the instance_choice defaults to your previous choice.
   4. Repeat iii for the following: `M3, M4, C3, C4, R3, G2, I2, D2`. Embrace the pain. 
