### PR TITLE
100517688 Fixes Erratic Argv Behaviors

### DIFF
--- a/lib/radiian.js
+++ b/lib/radiian.js
@@ -14,12 +14,21 @@
     .option('-o, --online-help', 'Opens online help');
 
   program
-    .command('init', 'initiate/start radiian')
-    .action(function(input) {
-      if(input !== 'init') {
-        console.log('\nError: unknown option `' + input + '`. Run `radiian --help` for help.\n');
+    .command('init')
+    .description('initiate/start radiian')
+    .action(function() {
+      if (process.argv.length > 3) {
+        console.log('Error: `radiian init` takes no arguments.');
+        process.exit(1);
       }
+      var init = require('./radiian-init');
     });
+
+  // Warning if two or more arguments are passed.
+  if (process.argv.length > 3) {
+    console.log('Warning: `radiian` only accepts one argument');
+    process.exit(1);
+  }
 
   program.parse(process.argv);
 
@@ -28,6 +37,13 @@
 
   if (program.onlineHelp) {
     openurl.open('https://github.com/radify/radiian#readme');
+    process.exit(0);
+  }
+
+  // Warning if unrecognized argument is passed
+  if (process.argv[2] !== 'init') {
+    console.log('Warning: unrecognized argument.');
+    process.exit(1);
   }
 
 }());


### PR DESCRIPTION
## [100517688](https://www.pivotaltracker.com/story/show/100517688) Fixes Erratic Argv Behaviors
## Description
- `radiian` without args displays help menu
- The ordinary flags (-h, -V, and -o) work as expected.
- `radiian init` starts Radiian.
- `radiian init foobar` issues a warning.
- `radiian foo bar baz` issues a warning.
- Passing `foo bar baz`to `radiian -h` or `radiian -v` issues a warning.
- `radiian foo init` issues a warning
- On the help menu, `help [cmd]` should not appear.
## Test Script
- **Assert that** everything in this PR's description works as described. 
