### PR TITLE
100359688 and 100358900: Fixes Two Permission Errors

### DIFF
--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -66,6 +66,10 @@
         .then(mkdir('ansible/roles/' + answers.appName + '/tasks'))
         .then(getReader('roles/appName/tasks/main.yaml.mustache')).then(render).then(getWriter('ansible/roles/' + answers.appName + '/tasks/main.yaml'))
         .then(getReader('myApp.pem.mustache')).then(render).then(getWriter('ansible/' + answers.app_pem))
+        .finally(function() {
+          fs.chmod('ansible/provision.sh', '0744');
+          fs.chmod('ansible/inventory/ec2.py', '0744');
+        })
         .catch(handler);
     }
   };


### PR DESCRIPTION
## [#100359688](https://www.pivotaltracker.com/story/show/100359688) Make `ec2.py` executable
## [#100358900](https://www.pivotaltracker.com/story/show/100358900) Make `provision.sh` executable
### Description
- Previously, `ansible/provision.sh` and `ansible/inventory/ec2.py`
  were not executable.
- This commit makes them executable with `0744` permissions.
- Gav's work on the following commit was essential to this fix.
  - 27378408f4616230922162badd508ae282e2e887
### Test Script
- In the `radiian` root directory, run `rm -rf ansible; lib/radiian.js init; ll ansible/provision.sh; ll ansible/inventory/ec2.py`
- **Assert that** `provision.sh` is executable
- **Assert that** `e2.py` is executable
