### PR TITLE
100755568 Fixes runtime error

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "homepage": "https://github.com/radify/radiian#readme",
   "devDependencies": {
-    "deasync": "^0.1.0",
     "gulp": "^3.9.0",
     "gulp-istanbul": "^0.10.0",
     "gulp-jasmine": "^2.0.1",
@@ -55,6 +54,7 @@
     "mkdirp": "^0.5.1",
     "mustache": "^2.1.2",
     "openurl": "^1.1.0",
+    "deasync": "^0.1.0",
     "q": "^1.4.1"
   },
   "preferGlobal": true


### PR DESCRIPTION
[100755568](https://www.pivotaltracker.com/story/show/100755568) Fixes runtime error
--

# Description

* Moves deasync from devDependencies to dependencies

# Test Script

* `https://github.com/radify/radiian.git`
* `cd radiian`
* `npm install --production`
  * You'll see warnings about missing dev dependencies. That's supposed to happen.
* `lib/radiian.js init`
* **Assert that** the Q/A script runs without error.