### PR TITLE
Bumps version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiian",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Radiian generates an Ansible playbook for immutable infrastructure with AWS.",
   "bin": "lib/radiian.js",
   "main": "lib/radiian.js",


### PR DESCRIPTION
Bumps version to 0.1.2
--

### There is no PT number because this was done in a rush. 

# Description

* I was forced to do this in order to publish our
  fixed version of radiian to npm
* This does not bump the git tag. I will do that separately.
* I already published 0.1.2 (this commit) to npm so that our
  users would not install the broken 0.1.1 release. 

# Test Script

* `npm install -g radiian`
* **Assert that** `radiian -V` reports `0.1.2`
* Run `radiian init`. **Assert that** there are no runtime errors. 