### PR TITLE
Various gulpfile changes and fixes

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,12 +1,17 @@
-var gulp = require('gulp');
-var jshint = require('gulp-jshint');
-var jscs = require('gulp-jscs');
-var jasmine = require('gulp-jasmine');
-var istanbul = require('gulp-istanbul');
+var gulp      = require('gulp');
+var jshint    = require('gulp-jshint');
+var jscs      = require('gulp-jscs');
+var jasmine   = require('gulp-jasmine');
+var istanbul  = require('gulp-istanbul');
+
+var paths = {
+  'spec' : 'spec/**/*.js',
+  'lib'  : 'lib/**/*.js'
+}
 
 // Proofread the code
 gulp.task('lint', function() {
-  return gulp.src(['lib/**/*.js'])
+  return gulp.src([paths.lib, paths.spec])
     .pipe(jshint())
     .pipe(jshint.reporter('default'))
     .pipe(jshint.reporter('fail'));
@@ -14,34 +19,39 @@ gulp.task('lint', function() {
 
 // Run the unit tests without any coverage calculations
 gulp.task('test', function() {
-  return gulp.src(['spec/**/*.js'])
+  return gulp.src([paths.spec])
       .pipe(jasmine());
 });
 
 // Task that calculates the unit test coverage for the module
 gulp.task('coverage', function() {
-  return gulp.src('lib/**/*.js')
-      .pipe(istanbul())
-      .pipe(istanbul.hookRequire())
-      .on('finish', function() {
-        gulp.src(['spec/**/*.js'])
-            .pipe(jasmine())
-            .pipe(istanbul.writeReports({
-              dir: 'build/coverage',
-              reportOpts: {dir: 'build/coverage'}
-            }));
-      });
+  return gulp.src(paths.lib)
+    .pipe(istanbul())
+    .pipe(istanbul.hookRequire())
+    .on('finish', function() {
+      gulp.src([paths.spec])
+        .pipe(jasmine())
+        .pipe(istanbul.writeReports({
+          dir: 'build/coverage',
+          reportOpts: {dir: 'build/coverage'}
+        }));
+    });
 });
 
 gulp.task('style', function() {
-  return gulp.src('lib/**/*.js')
+  return gulp.src(paths.lib)
     .pipe(jscs());
 });
 
 gulp.task('default', ['lint', 'style', 'test']);
 
-// On change to JavaScript files, run the default task
-gulp.task('dev', ['default'], function() {
-  gulp.watch(['spec/**/*.js', 'lib/**/*.js'], ['default']);
+// alias watch === dev
+gulp.task('watch', ['dev']);
+
+// On change to JavaScript files, run lint & test tasks
+// Do NOT run default: the style task breaks dev
+gulp.task('dev', ['lint', 'test'], function() {
+  gulp.watch([paths.spec, paths.lib], ['lint', 'test']);
 });
+
 gulp.task('ci', ['default']);


### PR DESCRIPTION
### Description
* Creates `paths` object
* Cleans up formatting
* Adds `spec` to lint task
* Removes jscs (that is, the `style` task) from dev task
  * `style` would constantly break `dev`, hence the need to remove it from `dev`
* Aliases `watch` to `dev`. That is, `gulp watch` calls `gulp dev`. 

### Test Script
1. Run `gulp`. **Assert that** the default task works.
1. Run `gulp dev`.
  1. **Assert that** it works.
  2. Break something.
  3. **Assert that** `lint` or `test` displays the error.
1. Repeat step two using `gulp watch`