### PR TITLE
Saves AWS keys for amend Q/A + Boilerplate Stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.4 - 2015-08-24
+* Fix
+    * The emendation dialogue now offers the AWS keys entered
+      during the first Q&A as the default values.
+
 ## 0.1.3 - 2015-08-20
 * Additions
     * A `CHANGELOG`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.1.4 - 2015-08-24
+* Adds devDependency badge to README
 * Fix
     * The emendation dialogue now offers the AWS keys entered
-      during the first Q&A as the default values.
+      during the first Q&A as the default values
 
 ## 0.1.3 - 2015-08-20
 * Additions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Travis Build Status](https://travis-ci.org/radify/radiian.svg)](https://travis-ci.org/radify/radiian?branch=master)
 [![npm version](https://badge.fury.io/js/radiian.svg)](http://npmjs.com/package/radiian)
 [![Dependency Status](https://david-dm.org/radify/radiian.svg)](https://david-dm.org/radify/radiian)
+[![devDependency Status](https://david-dm.org/radify/radiian/dev-status.svg)](https://david-dm.org/radify/radiian#info=devDependencies)
 
 # Radiian
 

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -314,8 +314,7 @@
   }, {
     type: 'input',
     name: 'aws_key',
-    message: 'What is your AWS Access Key?',
-    default: 'awsAccessKey',
+    message: 'What is your AWS Access Key (e.g. AKIAIOSFODNN7EXAMPLE)?',
     validate: function(value) {
       var regex =  regexes.awsKey;
 
@@ -326,8 +325,7 @@
   }, {
     type: 'input',
     name: 'aws_secret_key',
-    message: 'What is your AWS Secret Access Key?',
-    default: 'awsSecretKey',
+    message: 'What is your AWS Secret Access Key (e.g. wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY)?',
     validate: function(value) {
       var regex =  regexes.awsSecret;
       // This regex is essentially the same as the above, but it looks for 40 character,

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -26,6 +26,7 @@
       type: 'input',
       name: 'appName',
       message: function() {
+        // This clears the screen
         process.stdout.write('\u001b[2J\u001b[0;0H');
         return 'What is the name of your application?';
       },
@@ -314,6 +315,7 @@
     type: 'input',
     name: 'aws_key',
     message: 'What is your AWS Access Key?',
+    default: 'awsAccessKey',
     validate: function(value) {
       var regex =  regexes.awsKey;
 
@@ -325,6 +327,7 @@
     type: 'input',
     name: 'aws_secret_key',
     message: 'What is your AWS Secret Access Key?',
+    default: 'awsSecretKey',
     validate: function(value) {
       var regex =  regexes.awsSecret;
       // This regex is essentially the same as the above, but it looks for 40 character,

--- a/lib/radiian-init.js
+++ b/lib/radiian-init.js
@@ -29,11 +29,9 @@
         if (!confirmation.confirm) {
           // load existing answers as defaults into questions so user is modifying,
           // not starting from scratch
-          for (var i = 0; i < questions.length; i++) {
-            if (questions[i].default) {
-              questions[i].default = answers[questions[i].name];
-            }
-          }
+          questions.map(function(question) {
+            question.default = answers[question.name];
+          });
           go(questions);
         } else {
           submittedAnswers = answers;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiian",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Radiian generates an Ansible playbook for immutable infrastructure with AWS.",
   "bin": "lib/radiian.js",
   "main": "lib/radiian.js",


### PR DESCRIPTION
Saves AWS keys for amend Q/A + Boilerplate Stuff
--

### Description
* Stores the AWS keys that were first entered for the emendation process. 
* Bumps npm version number to 0.1.4
* Updates CHANGELOG
* Adds devDependency badge to README

### Next Actions
* If this PR is merged, please do the following:
  * Bump the release number to 0.1.4
  * Run `npm publish` to update Radiian's npm page. 

### Test Script

* Run `radiian init`
* Answer all of the questions
* For the AWS Key question, use *AKIAIOSFODNN7EXAMPLE*
 * For the AWS Secret Key question, use *wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY*
* Enter "n" when asked to confirm if the data is correct
* Answer the questions again
* When you reach the AWS Key question, **assert that** the new default is *AKIAIOSFODNN7EXAMPLE*
* When you reach the AWS Secret Key question, **assert that** the new default is *wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY*