### PR TITLE
Adds ami id question

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -7,7 +7,7 @@ var istanbul  = require('gulp-istanbul');
 var paths = {
   'spec' : 'spec/**/*.js',
   'lib'  : 'lib/**/*.js'
-}
+};
 
 // Proofread the code
 gulp.task('lint', function() {

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -313,6 +313,16 @@
     }
   }, {
     type: 'input',
+    name: 'ami_id',
+    message: 'What AMI ID would you like to use? (E.g., ami-47a23a30)',
+    validate: function(value) {
+      var regex =  regexes.ami;
+      var errorMessage = 'The AMI ID must begin with \"ami-\" and must end' +
+        ' with exactly eight lowercase, alphanumeric characters.';
+      return validateInput(value, regex, errorMessage);
+    }
+  }, {
+    type: 'input',
     name: 'aws_key',
     message: 'What is your AWS Access Key (e.g. AKIAIOSFODNN7EXAMPLE)?',
     validate: function(value) {

--- a/lib/regexes.js
+++ b/lib/regexes.js
@@ -5,6 +5,12 @@ module.exports = {
   pem: /(.pem)$/,
 
   /**
+   * The AMI ID must begin with "ami-" and must end with exactly eight,
+   * lowercase, alphanumeric characters.
+   */
+  ami: /^ami-[a-z0-9]{8}$/,
+
+  /**
    * AWS Key validation
    *
    * In plain English:

--- a/lib/templates/immutable.yaml.mustache
+++ b/lib/templates/immutable.yaml.mustache
@@ -7,8 +7,8 @@
     region: '{{ region }}'
     aws_zone: '{{ aws_zone }}'
   tasks:
-  - name: Launch instance (Ubuntu 14.04 hvm)
-    ec2: image='ami-9eaa1cf6'
+  - name: Launch Instance
+    ec2: image='{{ ami_id }}'
          instance_type="{{=<% %>=}}{{ instance_type }}<%={{ }}=%>"
          keypair='{{ keypair }}'
          instance_tags='{"Environment":"{{ environment }}","Class":"{{ className }}-immutable","Name":"{{ appName }} (immutable)"}'

--- a/spec/lib/questionsSpec.js
+++ b/spec/lib/questionsSpec.js
@@ -2,8 +2,8 @@ var questions = require('../../lib/questions.js');
 
 describe('questions.js', function() {
   describe('format', function() {
-    it('should be an array of 24 questions', function() {
-      expect(questions.length).toEqual(24);
+    it('should be an array of 25 questions', function() {
+      expect(questions.length).toEqual(25);
     });
   });
 });


### PR DESCRIPTION
Adds ami id question
--

### Description
* Queries user for ami id type
* Does _not_ provide a default value
* Uses a regex to confirm correct input
* Adds `{{ ami_id }}` to `immutable.yaml` Mustache template

### Test
* Run `./lib/radiian.js init`
* Continue to the ami question
* **Assert that** there is an ami question
* **Assert that** it gives an example ami id
* **Assert that** it has no default value
* Input a bad value
* **Assert that** Radiian rejects the bad value
* **Assert that** Radiian defines a correct value
* Input a good value
* **Assert that** Radiian accepts good input
* At the confirmation prompt, input `no`
* Continue to the ami question
* **Assert that** it contains the value entered on the first pass through the questions.
* Open `ansible/immutable.yaml`
* On line 11, **Assert that** the id in single quotes is the ami id value you entered from the dialogue