### PR TITLE
Prepares Radiian for public release announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.5 - 2015-09-08
+
+* Adds AMI ID question
+* Fixes `ec2.py` permissions
+* Improves `provision.sh`
+* Improves keypair question
+* Updates README
+
 ## 0.1.4 - 2015-08-24
 * Adds devDependency badge to README
 * Fix

--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-Radiian is released under the [MIT License](LICENSE.txt).
+Radiian is released under the [BSD 3-clause “New” License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiian",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Radiian generates an Ansible playbook for immutable infrastructure with AWS.",
   "bin": "lib/radiian.js",
   "main": "lib/radiian.js",
@@ -29,7 +29,7 @@
       "email": "gavin@radify.io",
       "url": "http://radify.io"
   }],
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/radify/radiian/issues"
   },


### PR DESCRIPTION
Prepares Radiian for public release announcement
--

* Updates CHANGELOG
* Changes license name in README and package.json to BSD-3-Clause
* Note that the license itself did not need to be changed because it was already BSD-3-Clause. 