### PR TITLE
Adds node v4.0 to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - 0.12
+  - 4.0
 
 before_install:
   - npm install -g gulp
@@ -9,3 +10,8 @@ before_install:
 
 script:
   - gulp ci
+
+matrix:
+  allow_failures:
+    - node_js: 4.0
+


### PR DESCRIPTION
Adds node v4.0 to Travis build
--

### Description
* Adds node v4.0 to Travis build
* **Please note**: the v4.0 build _is allowed to fail_ for the time being. Node 4 was released yesterday, and it might take a while for all the dependencies to catch up. 
* As expected, the v4.0 build failed on `npm install`, but the primary 0.12 build passed. 