### PR TITLE
Fixes broken code in Generator.js

### DIFF
--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -5,13 +5,14 @@
   var fs = require('fs');
   var Q = require('q');
   var mkdirp = require('mkdirp');
+  // create promise versions of read and write files
+  var read = Q.denodeify(fs.readFile);
+  var write = Q.denodeify(fs.writeFile);
 
   module.exports = {
     generate: function(answers) {
 
-      // create promise versions of read and write files, chmod, and mkdirp
-      var read = Q.denodeify(fs.readFile);
-      var write = Q.denodeify(fs.writeFile);
+      // create promise versions of chmod and mkdirp
       var chmod = Q.denodeify(fs.chmod);
       var mkdir = Q.denodeify(mkdirp);
 
@@ -36,18 +37,18 @@
           fs.chmod('ansible/inventory/ec2.py', '0755');
         })
         .catch(handler);
+
+      /**
+       * Render a template by injecting answers into it
+       *
+       * @param {String} template
+       * @returns {String} rendered template
+       */
+      function render(template) {
+        return mustache.render(template, answers);
+      }
     }
   };
-
-  /**
-   * Render a template by injecting answers into it
-   *
-   * @param {String} template
-   * @returns {String} rendered template
-   */
-  function render(template) {
-    return mustache.render(template, answers);
-  }
 
   /**
    * Partial application - creates a function which allows reading and returns a promise


### PR DESCRIPTION
Fixes broken code in Generator.js
--

### Description

* PR #62 inadvertently broke `Generator.js` due to a poorly thought-out rebase
* This PR fixes `Generator.js`


### Test Script

* Run `./lib/radiian.js init`
* Answer the questions
* **Assert that** no errors are thrown

### A Word on Tests

* A proper test suite would have caught this error.
* Ergo, a proper suite must be created.
* In Issue #66, I have assigned myself the task of building up the test suite. 