### PR TITLE
Fixes security vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.1.7] - 2015-12-28
 ### Added
 - CodeClimate Integration via Travis
 - CodeClimate badge to README
@@ -13,6 +15,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Reformats CHANGELOG in accord with [Keep a CHANGELOG](http://keepachangelog.com/)
 - Changes mustache tags in order **not** to escape HTML special characters
 - Simplifies `Generator.js`
+
+### Security
+- Removes a security vulnerability by updating `mustache`
 
 ### Updated
 - Dependencies
@@ -66,7 +71,8 @@ during the first Q&A as the default values
 ## 0.1.1 - 2015-08-06
 - Initial Release
 
-[Unreleased]: https://github.com/radify/radiian/compare/0.1.6...HEAD
+[Unreleased]: https://github.com/radify/radiian/compare/0.1.7...HEAD
+[0.1.7]: https://github.com/radify/radiian/compare/0.1.6...0.1.7
 [0.1.6]: https://github.com/radify/radiian/compare/0.1.5...0.1.6
 [0.1.5]: https://github.com/radify/radiian/compare/0.1.4...0.1.5
 [0.1.4]: https://github.com/radify/radiian/compare/0.1.3...0.1.4

--- a/package.json
+++ b/package.json
@@ -42,18 +42,18 @@
   "homepage": "https://github.com/radify/radiian#readme",
   "devDependencies": {
     "gulp": "^3.9.0",
-    "gulp-istanbul": "^0.10.2",
+    "gulp-istanbul": "^0.10.3",
     "gulp-jasmine": "^2.2.1",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.0",
-    "gulp-nsp": "^2.1.0",
-    "jscs": "^2.6.0"
+    "gulp-nsp": "^2.2.1",
+    "jscs": "^2.7.0"
   },
   "dependencies": {
     "commander": "^2.9.0",
     "inquirer": "^0.11.0",
     "mkdirp": "^0.5.1",
-    "mustache": "^2.2.0",
+    "mustache": "^2.2.1",
     "openurl": "^1.1.0",
     "deasync": "^0.1.4",
     "q": "^1.4.1"


### PR DESCRIPTION
### Fixes security vulnerability

* There's a vulnerability in the previous version of `mustache` whereby quoteless attributes in templates can lead to content injection
* This PR updates all dependencies, including `mustache`, to their current version. This should resolve the security issue. 
* To prepare for the next npm release, the changelog was updated accordingly