### PR TITLE
Refactor generator to callback + drop deasync

### DIFF
--- a/lib/radiian-init.js
+++ b/lib/radiian-init.js
@@ -5,14 +5,11 @@
   var generator = require('./Generator');
   var questions = require('./questions');
 
-  var userHappy = false;
-  var submittedAnswers = null;
-
   function clear() {
     process.stdout.write('\u001b[2J\u001b[0;0H');
   }
 
-  function go(questions) {
+  function go(questions, success) {
     clear();
     inquirer.prompt(questions, function(answers) {
       inquirer.prompt([{
@@ -32,24 +29,20 @@
           questions.map(function(question) {
             question.default = answers[question.name];
           });
-          go(questions);
+          go(questions, success);
         } else {
-          submittedAnswers = answers;
-          userHappy = true;
+          success(answers);
         }
       });
     });
   }
 
-  go(questions);
+  go(questions, function(answers) {
+    console.log('Generating playbook for an app named ' + answers.appName + ' in ./ansible...');
+    generator.generate(answers);
 
-  require('deasync').loopWhile(function() {
-    return !userHappy;
+    console.log('... done! Check out ./ansible for your playbook.');
+    console.log('Please make sure that you update ansible/' + answers.appPem);
   });
 
-  console.log('Generating playbook for an app named ' + submittedAnswers.appName + ' in ./ansible...');
-  generator.generate(submittedAnswers);
-
-  console.log('... done! Check out ./ansible for your playbook.');
-  console.log('Please make sure that you update ansible/' + submittedAnswers.appPem);
 }());

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "mkdirp": "^0.5.1",
     "mustache": "^2.2.1",
     "openurl": "^1.1.0",
-    "deasync": "^0.1.4",
     "q": "^1.4.1"
   },
   "preferGlobal": true


### PR DESCRIPTION
The `deasync` module failed to build on my machine when running `npm install -g radiian`, hence it borks the install of the whole command (looking at the issue tracker, it looks like it fails to build a lot...).

Anyway, I refactored the code to drop the dependency, which had the happy side-effect of eliminating some state.