### PR TITLE
Made ami-fce3c696(ubuntu) the default AMI

### DIFF
--- a/lib/questions.js
+++ b/lib/questions.js
@@ -321,7 +321,8 @@
       var errorMessage = 'The AMI ID must begin with \"ami-\" and must end' +
         ' with exactly eight lowercase, alphanumeric characters.';
       return validateInput(value, regex, errorMessage);
-    }
+    },
+    default: "ami-fce3c696"
   }, {
     type: 'input',
     name: 'aws_key',


### PR DESCRIPTION
The makes ami-fce3c696 the default AMI.

Fixes #77 
