### PR TITLE
aws_keys and appName.pem added to .gitignore

### DIFF
--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -16,10 +16,21 @@
       var chmod = Q.denodeify(fs.chmod);
       var mkdir = Q.denodeify(mkdirp);
 
+      //function that handles .gitignore
+      function gitignore(path){
+        return function(){
+          return fs.appendFile('.gitignore', "\n" + path, function(err){
+            if(err) return Promise.reject(err);
+            return Promise.resolve();
+          });
+        };
+      }
+
       // Kick off a promise chain
       mkdir('ansible/inventory', '0755')
         .then(getReader('ansible.cfg.mustache')).then(render).then(getWriter('ansible/ansible.cfg'))
         .then(getReader('aws_keys.mustache')).then(render).then(getWriter('ansible/inventory/aws_keys'))
+        .then(gitignore('ansible/inventory/aws_keys'))
         .then(getReader('destroy-old-nodes.yaml.mustache')).then(render)
           .then(getWriter('ansible/destroy-old-nodes.yaml'))
         .then(getReader('ec2.ini.mustache')).then(render).then(getWriter('ansible/inventory/ec2.ini'))
@@ -32,6 +43,7 @@
         .then(getReader('roles/appName/tasks/main.yaml.mustache')).then(render).then(getWriter('ansible/roles/' +
           answers.appName + '/tasks/main.yaml'))
         .then(getReader('myApp.pem.mustache')).then(render).then(getWriter('ansible/' + answers.appPem))
+        .then(gitignore('ansible/' + answers.appPem))
         .finally(function() {
           fs.chmod('ansible/provision.sh', '0744');
           fs.chmod('ansible/inventory/ec2.py', '0755');
@@ -85,4 +97,3 @@
   }
 
 }());
-


### PR DESCRIPTION
Adds a gitignore function to the generator that creates a `.gitgnore` if needed, then appends a path to it.
Generator now automatically adds `ansible/aws_keys` and `ansible/appName.pem to the .gitignore

Fixes #80